### PR TITLE
Added option to clear search input on show

### DIFF
--- a/app/search.js
+++ b/app/search.js
@@ -18,6 +18,15 @@ searchInput.addEventListener('input', function () {
   search(this.value)
 })
 
+ipc.on('forget-input', function (event, message) {
+  var pref = JSON.parse(window.localStorage.getItem('preference'))
+  var remember = pref['remember-input']
+  if (!remember) {
+    searchInput.value = ''
+    search('')
+  }
+})
+
 document.addEventListener('mousewheel', function (e) {
   if (e.deltaY % 1 !== 0) {
     e.preventDefault()

--- a/app/search.js
+++ b/app/search.js
@@ -23,6 +23,7 @@ ipc.on('forget-input', function (event, message) {
   var remember = pref['remember-input']
   if (!remember) {
     searchInput.value = ''
+    searchInput.focus()
     search('')
   }
 })

--- a/app/search.js
+++ b/app/search.js
@@ -18,14 +18,8 @@ searchInput.addEventListener('input', function () {
   search(this.value)
 })
 
-ipc.on('forget-input', function (event, message) {
-  var pref = JSON.parse(window.localStorage.getItem('preference'))
-  var remember = pref['remember-input']
-  if (!remember) {
-    searchInput.value = ''
-    searchInput.focus()
-    search('')
-  }
+ipc.on('show', function (event, message) {
+  searchInput.focus()
 })
 
 document.addEventListener('mousewheel', function (e) {
@@ -78,7 +72,8 @@ function copyFocusedEmoji (emoji, copyText) {
     data = emoji.innerText
   }
   clipboard.writeText(data)
-
+  searchInput.value = ''
+  search('')
   ipc.send('abort')
 }
 

--- a/app/settings.js
+++ b/app/settings.js
@@ -6,13 +6,9 @@ var defaultPreference = {
   'emoji-size': '20'
 }
 
-var preferenceSettings = {
-  'open-window-shortcut': {
-    title: 'Mojibar shortcut', type: 'text'
-  },
-  'emoji-size': {
-    title: 'Emoji font size', type: 'text'
-  }
+var preferenceNames = {
+  'open-window-shortcut': 'Mojibar shortcut',
+  'emoji-size': 'Emoji font size'
 }
 
 var applyPreferences = function (preference, initialization) {
@@ -24,8 +20,7 @@ var applyPreferences = function (preference, initialization) {
 
 var savePreference = function () {
   Object.keys(preference).forEach(function (key) {
-    var input = document.getElementById(key)
-    preference[key] = input.type === 'checkbox' ? input.checked : input.value
+    preference[key] = document.getElementById(key).value
   })
 
   window.localStorage.setItem('preference', JSON.stringify(preference))
@@ -36,7 +31,7 @@ var savePreference = function () {
 if (window.localStorage.getItem('preference')) {
   preference = JSON.parse(window.localStorage.getItem('preference'))
   Object.keys(defaultPreference).forEach(function (key) {
-    if (!preference[key] && preference[key] !== false) preference[key] = defaultPreference[key]
+    if (!preference[key]) preference[key] = defaultPreference[key]
   })
 } else {
   preference = defaultPreference
@@ -70,17 +65,11 @@ var togglePreferencePanel = function () {
     panel.classList.add('preference-panel')
     panel.id = 'js-preference-panel'
     var html = '<form>'
-    Object.keys(preferenceSettings).forEach(function (key) {
+    Object.keys(preferenceNames).forEach(function (key) {
       html += '<div class="pref-item"><label for="' + key + '">'
-      html += preferenceSettings[key].title
+      html += preferenceNames[key]
       html += '</label>'
-      html += '<input id="' + key + '" '
-      if (preferenceSettings[key].type === 'checkbox') {
-        html += 'type="checkbox"' + (preference[key] ? ' checked' : '')
-      } else {
-        html += 'type="text" value="' + preference[key] + '" placeholder="' + defaultPreference[key] + '"'
-      }
-      html += '>'
+      html += '<input type=" text" id="' + key + '" value="' + preference[key] + '" placeholder="' + defaultPreference[key] + '">'
       html += '</div>'
     })
     html += '<label></label><button type="submit">Save</button>'

--- a/app/settings.js
+++ b/app/settings.js
@@ -3,8 +3,7 @@ var ipc = require('electron').ipcRenderer
 
 var defaultPreference = {
   'open-window-shortcut': 'ctrl+shift+space',
-  'emoji-size': '20',
-  'remember-input': true
+  'emoji-size': '20'
 }
 
 var preferenceSettings = {
@@ -13,9 +12,6 @@ var preferenceSettings = {
   },
   'emoji-size': {
     title: 'Emoji font size', type: 'text'
-  },
-  'remember-input': {
-    title: 'Remember user input', type: 'checkbox'
   }
 }
 

--- a/app/settings.js
+++ b/app/settings.js
@@ -3,12 +3,20 @@ var ipc = require('electron').ipcRenderer
 
 var defaultPreference = {
   'open-window-shortcut': 'ctrl+shift+space',
-  'emoji-size': '20'
+  'emoji-size': '20',
+  'remember-input': true
 }
 
-var preferenceNames = {
-  'open-window-shortcut': 'Mojibar shortcut',
-  'emoji-size': 'Emoji font size'
+var preferenceSettings = {
+  'open-window-shortcut': {
+    title: 'Mojibar shortcut', type: 'text'
+  },
+  'emoji-size': {
+    title: 'Emoji font size', type: 'text'
+  },
+  'remember-input': {
+    title: 'Remember user input', type: 'checkbox'
+  }
 }
 
 var applyPreferences = function (preference, initialization) {
@@ -20,7 +28,8 @@ var applyPreferences = function (preference, initialization) {
 
 var savePreference = function () {
   Object.keys(preference).forEach(function (key) {
-    preference[key] = document.getElementById(key).value
+    var input = document.getElementById(key)
+    preference[key] = input.type === 'checkbox' ? input.checked : input.value
   })
 
   window.localStorage.setItem('preference', JSON.stringify(preference))
@@ -31,7 +40,7 @@ var savePreference = function () {
 if (window.localStorage.getItem('preference')) {
   preference = JSON.parse(window.localStorage.getItem('preference'))
   Object.keys(defaultPreference).forEach(function (key) {
-    if (!preference[key]) preference[key] = defaultPreference[key]
+    if (!preference[key] && preference[key] !== false) preference[key] = defaultPreference[key]
   })
 } else {
   preference = defaultPreference
@@ -65,11 +74,17 @@ var togglePreferencePanel = function () {
     panel.classList.add('preference-panel')
     panel.id = 'js-preference-panel'
     var html = '<form>'
-    Object.keys(preferenceNames).forEach(function (key) {
+    Object.keys(preferenceSettings).forEach(function (key) {
       html += '<div class="pref-item"><label for="' + key + '">'
-      html += preferenceNames[key]
+      html += preferenceSettings[key].title
       html += '</label>'
-      html += '<input type=" text" id="' + key + '" value="' + preference[key] + '" placeholder="' + defaultPreference[key] + '">'
+      html += '<input id="' + key + '" '
+      if (preferenceSettings[key].type === 'checkbox') {
+        html += 'type="checkbox"' + (preference[key] ? ' checked' : '')
+      } else {
+        html += 'type="text" value="' + preference[key] + '" placeholder="' + defaultPreference[key] + '"'
+      }
+      html += '>'
       html += '</div>'
     })
     html += '<label></label><button type="submit">Save</button>'

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ var mb = menubar({ dir: __dirname + '/app', width: 440, height: 230, icon: __dir
 var Menu = require('menu')
 
 mb.on('show', function () {
-  mb.window.webContents.send('forget-input')
+  mb.window.webContents.send('show')
 })
 
 mb.app.on('will-quit', function () {

--- a/index.js
+++ b/index.js
@@ -4,6 +4,10 @@ var globalShortcut = require('global-shortcut')
 var mb = menubar({ dir: __dirname + '/app', width: 440, height: 230, icon: __dirname + '/app/Icon-Template.png', preloadWindow: true, 'window-position': 'topRight' })
 var Menu = require('menu')
 
+mb.on('show', function () {
+  mb.window.webContents.send('forget-input')
+})
+
 mb.app.on('will-quit', function () {
   globalShortcut.unregisterAll()
 })


### PR DESCRIPTION
Hey, I use `mojibar` a ton and love it! :rocket:

I added this option because I typically want different emoji and the fact that the search input is never cleared is annoying for my use case, as I typically would:

- open via shortcut
- type search query
- pick the emoji with keyboard
- paste the emoji on an input
- open via shortcut again
- _try to type search query, but pre-existing query gets in the way_
- _type search query anyways so that the input is focused_
- _clear input_
- type search query
- ...

This PR eliminates the italicized steps by adding a setting to forget the current input on `show`