### PR TITLE
Avoid mutation of emojikeys

### DIFF
--- a/app/search.js
+++ b/app/search.js
@@ -92,7 +92,7 @@ function search (query) {
   searching = setTimeout(function () {
     var results
     if (query.length === 0 || (query.length === 1 && query.charCodeAt() <= 255)) {
-      results = emojikeys
+      results = emojikeys.slice(0)
     } else {
       results = (Object.keys(index).filter(function matchQuery (keyword) {
         return keyword.match(query)
@@ -106,7 +106,7 @@ function search (query) {
     }
 
     // Put exact match first
-    if (results.indexOf(query) >= 0 ) {
+    if (results.indexOf(query) >= 0) {
       results.splice(results.indexOf(query), 1)
       results.unshift(query)
     }


### PR DESCRIPTION
:hammer: Fix for Issue #46 :hammer: 

When single character queries such as "a" and "b" passed the check: `if (results.indexOf(query) >= 0) ` it resulted in the order of the original emojikeys being mutated too. This was due to the results array being assigned the exact reference of the emojikeys array.

This PR fixes the issue by making sure we're always working with a clone of the emojikeys :dancers: 