### PR TITLE
Add option to launch at startup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+Mojibar-darwin-x64

--- a/app/style.css
+++ b/app/style.css
@@ -106,10 +106,13 @@ button {
 .preference-panel input {
   padding: 10px 13px;
   font-size: 13px;
-  width: 70%;
   border-radius: 3px;
   border: 1px solid #ddd;
   font-family: menlo, monospace;
+}
+
+.preference-panel input[type="text"] {
+  width: 70%;
 }
 
 .preference-panel button {

--- a/index.js
+++ b/index.js
@@ -1,8 +1,10 @@
 var menubar = require('menubar')
+var app = require('electron').app
 var ipc = require('electron').ipcMain
 var globalShortcut = require('electron').globalShortcut
-var mb = menubar({ dir: __dirname + '/app', width: 440, height: 230, icon: __dirname + '/app/Icon-Template.png', preloadWindow: true, windowPosition: 'topRight' })
+var mb = menubar({ dir: __dirname + '/app', width: 440, height: 270, icon: __dirname + '/app/Icon-Template.png', preloadWindow: true, windowPosition: 'topRight' })
 var Menu = require('electron').Menu
+var isDev = require('electron-is-dev')
 
 mb.on('show', function () {
   mb.window.webContents.send('show')
@@ -21,9 +23,17 @@ ipc.on('abort', function () {
   mb.hideWindow()
 })
 
-// when receive the abort message, close the app
+// update shortcuts when preferences change
 ipc.on('update-preference', function (evt, pref, initialization) {
   registerShortcut(pref['open-window-shortcut'], initialization)
+
+  // Make packaged app (not dev app) start at login
+  if (!isDev) {
+    app.setLoginItemSettings({
+      openAtLogin: pref['open-at-login'],
+      openAsHidden: true
+    })
+  }
 })
 
 var template = [

--- a/package.json
+++ b/package.json
@@ -4,17 +4,18 @@
   "description": "A menubar app adaptation of Emoji searcher.",
   "main": "index.js",
   "dependencies": {
+    "electron-is-dev": "^0.1.2",
     "emojilib": "2.0.2",
     "menubar": "^5.1.0"
   },
   "devDependencies": {
-    "electron-packager": "^7.4.0",
-    "electron-prebuilt": "^1.3.2",
+    "electron": "^1.4.0",
+    "electron-packager": "^8.0.0",
     "standard": "^4.5.3"
   },
   "scripts": {
     "start": "electron .",
-    "build": "electron-packager . Mojibar --platform=darwin --arch=x64 --version=1.3.2 --overwrite --icon=mojibar",
+    "build": "electron-packager . Mojibar --platform=darwin --arch=x64 --overwrite --icon=mojibar",
     "test": "standard index.js app/search.js app/settings.js"
   },
   "repository": {


### PR DESCRIPTION
:wave:  @muan!

This is an experimental attempt to make mojibar start up automatically after a system restart using [auto-launch](https://github.com/Teamwork/node-auto-launch). I followed the [basic setup instructions](https://github.com/Teamwork/node-auto-launch) and it is indeed launching at startup, but instead of seeing the mojibar icon in the menubar, I see the vanilla electron window:

![screen shot 2016-03-31 at 9 43 15 pm](https://cloud.githubusercontent.com/assets/2289/14198017/5c941644-f78a-11e5-993e-24eb245c4371.png)

Maybe one of the auto-launch maintainers like @4ver or @adam-lynch can help us figure it out?
