### PR TITLE
I have added support to win32

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "app": "electron .",
     "build": "electron-packager . Mojibar --platform=darwin --arch=x64 --version=0.36.5 --overwrite --icon=mojibar",
-    "build-win":"electron-packager . Mojibar --platform=win32 --arch=x64 --version=0.36.5 --overwrite --icon=mojibar"
+    "build-win":"electron-packager . Mojibar --platform=win32 --arch=x64 --version=0.36.5 --overwrite --icon=mojibar",
     "test": "standard index.js app/search.js app/settings.js"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "scripts": {
     "app": "electron .",
     "build": "electron-packager . Mojibar --platform=darwin --arch=x64 --version=0.36.5 --overwrite --icon=mojibar",
+    "build-win":"electron-packager . Mojibar --platform=win32 --arch=x64 --version=0.36.5 --overwrite --icon=mojibar"
     "test": "standard index.js app/search.js app/settings.js"
   },
   "repository": {


### PR DESCRIPTION
Please merge this pull-request. I have added support to windows platform.
To build for windows, just need to do:

`npm run build-run`
I also attaching a ZIP file, that contain the profram + `.exe` file. you can directly put in the releases here on GitHub.

Thank you.
