### PR TITLE
Fix issue with scrolling for uneven screen widths and heights

### DIFF
--- a/app/search.js
+++ b/app/search.js
@@ -181,8 +181,8 @@ function jumpto (destination) {
   var all = document.getElementsByClassName('emoji')
   var focusedElement = document.querySelector('.emoji:focus')
   var nodeIndex = Array.prototype.indexOf.call(all, focusedElement)
-  var resultPerRow = Number((container.clientWidth / all[0].clientWidth).toFixed())
-  var resultPerCol = Number((container.clientHeight / all[0].clientHeight).toFixed())
+  var resultPerRow = Math.floor(container.clientWidth / all[0].clientWidth)
+  var resultPerCol = Math.floor(container.clientHeight / all[0].clientHeight)
   var newTarget
 
   if (destination === 'up') {


### PR DESCRIPTION
The old method rounded up, causing the selector to move diagonally when sufficient white space was present at the margin. The new method only rounds down and thus avoids this issue.