### PR TITLE
Add editorconfig to keep style standard btw editors

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+


### PR DESCRIPTION
Add a default behaves between editors to keep an code style.

While doing #78 using vim, my editor didn't behave properly while trying to indent. Maybe we can add one `.editorconfig` file so that we can share indentation/break line across editors.