### PR TITLE
Add support to paste after close when copy

### DIFF
--- a/app/search.js
+++ b/app/search.js
@@ -76,7 +76,7 @@ function copyFocusedEmoji (emoji, copyText) {
   clipboard.writeText(data)
   searchInput.value = ''
   search('')
-  ipc.send('abort')
+  ipc.send('abort', 'copy')
 }
 
 document.addEventListener('keypress', function (evt) {

--- a/index.js
+++ b/index.js
@@ -5,6 +5,9 @@ var globalShortcut = require('electron').globalShortcut
 var mb = menubar({ dir: __dirname + '/app', width: 440, height: 270, icon: __dirname + '/app/Icon-Template.png', preloadWindow: true, windowPosition: 'topRight' })
 var Menu = require('electron').Menu
 var isDev = require('electron-is-dev')
+var os = require('os')
+var robot = require('robotjs')
+
 
 mb.on('show', function () {
   mb.window.webContents.send('show')
@@ -19,8 +22,20 @@ mb.app.on('activate', function () {
 })
 
 // when receive the abort message, close the app
-ipc.on('abort', function () {
+ipc.on('abort', function (event, copy) {
   mb.hideWindow()
+
+  if (!copy) {
+    return
+  }
+
+  setTimeout(function () {
+    if (os.platform() === 'darwin') {
+      robot.keyTap('v', 'command')
+    } else {
+      robot.keyTap('v', 'control')
+    }
+  }, 50)
 })
 
 // update shortcuts when preferences change

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "dependencies": {
     "electron-is-dev": "^0.1.2",
     "emojilib": "2.0.3",
-    "menubar": "^5.1.0"
+    "menubar": "^5.1.0",
+    "robotjs": "^0.4.5"
   },
   "devDependencies": {
     "electron": "^1.4.0",


### PR DESCRIPTION
It adds support to automatic paste in the old focus after "copy" from mojibar.

I have tested it in linux together with #78 

Not sure if it works in mac as I don't have one to test, but I think it might be related to #23 #58 #16 ... if someone can test it in mac let me know if it works...

If you have already run `npm install` its necessary to rebuild electron install as robot is a native extension to do it: `npm rebuild --runtime=electron --target=1.4.0 --disturl=https://atom.io/download/atom-shell --abi=48`