### PR TITLE
Restore previous application focus

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,10 @@ mb.on('show', function () {
   mb.window.webContents.send('show')
 })
 
+mb.on('after-hide', function() {
+  mb.app.hide()
+})
+
 mb.app.on('will-quit', function () {
   globalShortcut.unregisterAll()
 })


### PR DESCRIPTION
This change successfully restores focus to the previously focused application window. Tested on OSX `10.11.6`.