### PR TITLE
Issue #64: Ensure focus is reapplied to last active window when closing mojibar window.

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@ mb.app.on('activate', function () {
 
 // when receive the abort message, close the app
 ipcMain.on('abort', function () {
+  mb.window.blur()
   mb.hideWindow()
 })
 

--- a/index.js
+++ b/index.js
@@ -1,4 +1,6 @@
 var { app, ipcMain, globalShortcut, Menu } = require('electron')
+var isWin = /^win/.test(process.platform)
+var isMac = /darwin/.test(process.platform)
 var menubar = require('menubar')
 var mb = menubar({ dir: __dirname + '/app', width: 440, height: 270, icon: __dirname + '/app/Icon-Template.png', preloadWindow: true, windowPosition: 'topRight' })
 var isDev = require('electron-is-dev')
@@ -17,8 +19,13 @@ mb.app.on('activate', function () {
 
 // when receive the abort message, close the app
 ipcMain.on('abort', function () {
-  mb.window.blur()
-  mb.hideWindow()
+  if (isMac) {
+    mb.app.hide()
+  } else {
+    // Windows and Linux
+    mb.window.blur()
+    mb.hideWindow()
+  }
 })
 
 // update shortcuts when preferences change


### PR DESCRIPTION
Here's my fix  for #64 😎 

Can we see if this works for Mac 🍎 as well? 

**NOTE:** Per `process.versions.electron` I am running electron `v1.6.0`. Does that have anything to do with it?

![2017-02-17_21-58-04](https://cloud.githubusercontent.com/assets/4269377/23090832/33448b18-f55c-11e6-80d4-7ee441ee89ba.gif)
