### PR TITLE
⌨ Improvement for keyboard consistency.

### DIFF
--- a/app/search.js
+++ b/app/search.js
@@ -199,13 +199,17 @@ function jumpto (destination) {
     newTarget = nodeIndex + resultPerRow
   } else if (destination === 'left') {
     if ((nodeIndex + 1) % resultPerRow === 1) {
-      newTarget = nodeIndex + (resultPerRow - 1)
+      // Wrap to previous row.
+      newTarget = nodeIndex + (resultPerRow - 1) // Adjust to last column.
+      newTarget -= resultPerRow // Up one row.
     } else {
       newTarget = nodeIndex - 1
     }
   } else if (destination === 'right') {
     if ((nodeIndex + 1) % resultPerRow === 0) {
-      newTarget = nodeIndex - (resultPerRow - 1)
+      // Wrap to next row.
+      newTarget = nodeIndex - (resultPerRow - 1) // Adjust to first column.
+      newTarget += resultPerRow // Down one row.
     } else {
       newTarget = nodeIndex + 1
     }
@@ -215,10 +219,20 @@ function jumpto (destination) {
     newTarget = nodeIndex - resultPerRow * (resultPerCol - 1 || 1)
   }
 
-  if (newTarget < 0) newTarget = 0
+  if (newTarget < 0) {
+    // Allow jump back up to search field IF already at first item.
+    if (nodeIndex === 0) {
+	  // Purposefully mismatch so we focus on input instead.
+      newTarget = -1
+    } else {
+      newTarget = 0
+    }
+  }
   if (newTarget >= all.length - 1) newTarget = all.length - 1
   if (all[newTarget]) {
     all[newTarget].focus()
     all[newTarget].scrollIntoViewIfNeeded()
+  } else {
+    searchInput.focus()
   }
 }


### PR DESCRIPTION
Setup so that down 👇 goes down to emoji grid, up ☝️ goes back up to focus the search input 🔎, left/right wraps to next/previous lines like most applications. Super easy 🍰

I noticed in my testing for the other PR's I've got queued up, it was wrapping odd. Normally the experience when using the ⌨ keyboard to navigate through editors is for the cursor to continue to the next or previous row depending on your current position, not for it to keep wrapping back to the same line. Also, it makes sense from a UI/UX perspective for the ⬆️ key to actually take you back to the search field when ⬇️ key removes you from it.