### PR TITLE
Close window when losing focus

### DIFF
--- a/index.js
+++ b/index.js
@@ -117,6 +117,17 @@ mb.on('ready', function ready () {
   })
 })
 
+// Close the window when losing focus
+mb.on('focus-lost', function focus_lost () {
+  if (isMac) {
+    mb.app.hide()
+  } else {
+    // Windows and Linux
+    mb.window.blur()
+    mb.hideWindow()
+  }
+})
+
 // Register a shortcut listener.
 var registerShortcut = function (keybinding, initialization) {
   globalShortcut.unregisterAll()

--- a/index.js
+++ b/index.js
@@ -118,7 +118,7 @@ mb.on('ready', function ready () {
 })
 
 // Close the window when losing focus
-mb.on('focus-lost', function focus_lost () {
+mb.on('focus-lost', function focusLost () {
   if (isMac) {
     mb.app.hide()
   } else {

--- a/index.js
+++ b/index.js
@@ -120,7 +120,7 @@ mb.on('ready', function ready () {
 // Close the window when losing focus
 mb.on('focus-lost', function focusLost () {
   if (isMac) {
-    mb.app.hide()
+    mb.hideWindow()
   } else {
     // Windows and Linux
     mb.window.blur()


### PR DESCRIPTION
Tested on MacOS High Sierra. Allows the user to close the window by clicking outside of it.

Addresses #116 

![feature_gif](https://user-images.githubusercontent.com/6846386/37871607-4ea23400-2fb7-11e8-8c49-96a7831ccc96.gif)
