### PR TITLE
fix position to stick to tray icon

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ var mb = menubar({
   height: 330,
   icon: path.join(__dirname, '/app/Icon-Template.png'),
   preloadWindow: true,
-  windowPosition: 'topRight',
+  windowPosition: 'trayLeft',
   alwaysOnTop: true
 })
 


### PR DESCRIPTION
This fixes the window to the tray icon, so that it is not always in the far right corner.

**Old:** (panel is not attached to tray icon)
<img width="714" alt="screen shot 2018-11-01 at 15 33 36" src="https://user-images.githubusercontent.com/813754/47858119-987a3900-ddeb-11e8-9244-b564e603e113.png">

**New:** (panel **is** attached to tray icon)
<img width="912" alt="screen shot 2018-11-01 at 15 34 03" src="https://user-images.githubusercontent.com/813754/47858154-ad56cc80-ddeb-11e8-9fd1-f70c070bb35e.png">
